### PR TITLE
Stop serializing duplicate fields from the delegate ThrowableProblem

### DIFF
--- a/problem-json/src/main/java/io/micronaut/problem/ProblemErrorResponseProcessor.java
+++ b/problem-json/src/main/java/io/micronaut/problem/ProblemErrorResponseProcessor.java
@@ -115,7 +115,7 @@ public class ProblemErrorResponseProcessor implements ErrorResponseProcessor<Pro
     @Introspected
     static final class ThrowableProblemWithoutStacktrace implements Problem {
         @JsonUnwrapped
-        @JsonIgnoreProperties(value = {"stackTrace", "localizedMessage", "message"})
+        @JsonIgnoreProperties(value = {"stackTrace", "localizedMessage", "message", "type", "title", "status", "detail", "instance", "parameters"})
         final ThrowableProblem problem;
 
         ThrowableProblemWithoutStacktrace(ThrowableProblem problem) {

--- a/problem-json/src/test/groovy/io/micronaut/problem/NoDuplicatesInNonStackTraceResponseSpec.groovy
+++ b/problem-json/src/test/groovy/io/micronaut/problem/NoDuplicatesInNonStackTraceResponseSpec.groovy
@@ -1,0 +1,47 @@
+package io.micronaut.problem
+
+import io.micronaut.context.annotation.Requires
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.annotation.QueryValue
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+
+class NoDuplicatesInNonStackTraceResponseSpec extends EmbeddedServerSpecification {
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'problem.stack-trace': false
+        ]
+    }
+
+    @Override
+    String getSpecName() {
+        'NoDuplicatesInNonStackTraceResponseSpec'
+    }
+
+    def "properties are not duplicated with a no-stack-trace client error"() {
+        when:
+        def response = client.exchange('/client', String, String)
+
+        then:
+        HttpClientResponseException e = thrown()
+        with(e.response.body()) { String it ->
+            it.findAll('"type":').size() == 1
+            it.findAll('"parameters":').size() == 1
+            it.findAll('"detail":').size() == 1
+            it.findAll('"status":').size() == 1
+        }
+    }
+
+    @Requires(property = 'spec.name', value = 'NoDuplicatesInNonStackTraceResponseSpec')
+    @Controller('/client')
+    static class TaskController {
+
+        @Get
+        String index(@QueryValue String taskId) {
+            return taskId;
+        }
+    }
+
+}


### PR DESCRIPTION
We have a delegate ThrowableProblem which we use @JsonUnwrapped to pull into our response

We then delegate getters for known fields (I assume to maintain consistency should the
ThrowableProblem fields ever change name.

However we don't exclude those delegated fields from the @JsonUnwrapped field so we end
up with them twice in the response.  This wasn't detected before as the duplicates are
silently dropped when converting back to a Map in the tests.

Fixed this by ignoring the fields we delegate, and added a test to check for duplicate
keys in the response string.

Fixes #120