### PR TITLE
Add configuration property allowing users to omit/include the details field

### DIFF
--- a/problem-json/src/main/java/io/micronaut/problem/conf/ProblemConfiguration.java
+++ b/problem-json/src/main/java/io/micronaut/problem/conf/ProblemConfiguration.java
@@ -20,14 +20,22 @@ import io.micronaut.core.util.Toggleable;
 
 /**
  * Configuration for problem.
+ *
  * @author Sergio del Amo
  * @since 1.0.0
  */
 public interface ProblemConfiguration extends Toggleable {
 
     /**
-     *
      * @return Whether the HTTP Response should include the stack trace for instances of {@link org.zalando.problem.ThrowableProblem}
      */
     boolean isStackTrace();
+
+    /**
+     * @return Whether the HTTP Response should include the detailed, human-readable explanation of problems that are
+     * instances of {@link org.zalando.problem.ThrowableProblem}
+     */
+    default boolean isDetail() {
+        return false;
+    }
 }

--- a/problem-json/src/main/java/io/micronaut/problem/conf/ProblemConfigurationProperties.java
+++ b/problem-json/src/main/java/io/micronaut/problem/conf/ProblemConfigurationProperties.java
@@ -19,6 +19,7 @@ import io.micronaut.context.annotation.ConfigurationProperties;
 
 /**
  * {@link ConfigurationProperties} implementation of {@link ProblemConfiguration}.
+ *
  * @author Sergio del Amo
  * @since 1.0
  */
@@ -38,11 +39,30 @@ public class ProblemConfigurationProperties implements ProblemConfiguration {
      * The default stackTrace value.
      */
     @SuppressWarnings("WeakerAccess")
-    public static final boolean DEFAULT_STACK_TRACKE = false;
+    public static final boolean DEFAULT_STACK_TRACE = false;
+
+    /**
+     * The default stackTrace value.
+     *
+     * @deprecated for removal in Micronaut 4 or later. Use {@link #DEFAULT_STACK_TRACE} instead
+     */
+    @SuppressWarnings("WeakerAccess")
+    @Deprecated
+    public static final boolean DEFAULT_STACK_TRACKE = DEFAULT_STACK_TRACE;
+
+    /**
+     * The default isDetail value.
+     * <p>
+     * {@code True} until Micronaut 4 at which time the default will be changed to {@code false} which is a breaking change.
+     */
+    @SuppressWarnings("WeakerAccess")
+    public static final boolean DEFAULT_DETAIL = true;
 
     private boolean enabled = DEFAULT_ENABLED;
 
-    private boolean stackTrace = DEFAULT_STACK_TRACKE;
+    private boolean stackTrace = DEFAULT_STACK_TRACE;
+
+    private boolean detail = DEFAULT_DETAIL;
 
     @Override
     public boolean isEnabled() {
@@ -64,10 +84,22 @@ public class ProblemConfigurationProperties implements ProblemConfiguration {
     }
 
     /**
-     *
-     * @param stackTrace Whether the HTTP Response should include the stack trace for instances of {@link org.zalando.problem.ThrowableProblem}. Default value ({@value #DEFAULT_STACK_TRACKE}).
+     * @param stackTrace Whether the HTTP Response should include the stack trace for instances of {@link org.zalando.problem.ThrowableProblem}. Default value ({@value #DEFAULT_STACK_TRACE}).
      */
     public void setStackTrace(boolean stackTrace) {
         this.stackTrace = stackTrace;
+    }
+
+    @Override
+    public boolean isDetail() {
+        return detail;
+    }
+
+    /**
+     * @param detail Whether the HTTP Response should include the detailed, human-readable explanation of problems that are
+     *               instances of {@link org.zalando.problem.ThrowableProblem}.  See {@link #DEFAULT_DETAIL} regarding the default value.
+     */
+    public void setDetail(boolean detail) {
+        this.detail = detail;
     }
 }

--- a/problem-json/src/test/groovy/io/micronaut/problem/DataLeakageSpec.groovy
+++ b/problem-json/src/test/groovy/io/micronaut/problem/DataLeakageSpec.groovy
@@ -1,0 +1,48 @@
+package io.micronaut.problem
+
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.annotation.Controller
+import io.micronaut.http.annotation.Get
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+
+class DataLeakageSpec extends EmbeddedServerSpecification {
+    @Override
+    Map<String, Object> getConfiguration() {
+        super.configuration + [
+                'problem.stack-trace': false,
+                'problem.detail'     : false
+        ]
+    }
+
+    @Override
+    String getSpecName() {
+        'DataLeakageSpec'
+    }
+
+    void "No unintended data leakage in instances of Problem"() {
+        when:
+        Argument<?> okArg = Argument.of(String)
+        Argument<?> errorArg = Argument.of(Map)
+        client.exchange(HttpRequest.GET('/foo'), okArg, errorArg)
+
+        then:
+        HttpClientResponseException thrown = thrown()
+        Optional<Map> bodyOptional = thrown.response.getBody(errorArg)
+        bodyOptional.isPresent()
+        bodyOptional.get().keySet().size() == 2
+        bodyOptional.get()['status'] == 500
+        bodyOptional.get()['type'] == "about:blank"
+    }
+
+    @Controller('/foo')
+    static class FooController {
+
+        @Get
+        void doSomething() {
+            throw new Exception("foo data");
+        }
+    }
+}

--- a/problem-json/src/test/groovy/io/micronaut/problem/TaskNotFoundProblemWithStackTraceSpec.groovy
+++ b/problem-json/src/test/groovy/io/micronaut/problem/TaskNotFoundProblemWithStackTraceSpec.groovy
@@ -42,10 +42,8 @@ class TaskNotFoundProblemWithStackTraceSpec extends EmbeddedServerSpecification 
 
         then:
         bodyOptional.isPresent()
-        bodyOptional.get().keySet().size() == 7
+        bodyOptional.get().keySet().size() == 5
         bodyOptional.get().keySet().contains('stackTrace')
-        bodyOptional.get().keySet().contains('message')
-        bodyOptional.get().keySet().contains('localizedMessage')
         bodyOptional.get()['status'] == 404
         bodyOptional.get()['title'] == 'Not found'
         bodyOptional.get()['detail'] == "Task '3' not found"


### PR DESCRIPTION
The "details" field of Problem can potentially leak data. Fixes #144.