### PR TITLE
Remove Spock version force configuration

### DIFF
--- a/settings.gradle
+++ b/settings.gradle
@@ -6,7 +6,7 @@ pluginManagement {
 }
 
 plugins {
-    id("io.micronaut.build.shared.settings") version "8.0.0-M12"
+    id("io.micronaut.build.shared.settings") version "8.0.0-M17"
 }
 
 enableFeaturePreview("TYPESAFE_PROJECT_ACCESSORS")

--- a/test-suite-groovy/build.gradle
+++ b/test-suite-groovy/build.gradle
@@ -18,9 +18,3 @@ dependencies {
 tasks.named('test') {
     useJUnitPlatform()
 }
-//TODO remove once Micronaut Test ships Spock version compatible with Groovy 5
-configurations.all {
-    resolutionStrategy {
-        force("org.spockframework:spock-core:2.4-M7-groovy-5.0")
-    }
-}


### PR DESCRIPTION
Removed the Spock version force configuration from build.gradle as it is no longer needed.