### PR TITLE
Keep the exception message in an opted-in problem detail on core 5.2

### DIFF
--- a/problem-json/src/main/java/io/micronaut/problem/ProblemJsonErrorResponseBodyProvider.java
+++ b/problem-json/src/main/java/io/micronaut/problem/ProblemJsonErrorResponseBodyProvider.java
@@ -95,11 +95,32 @@ public class ProblemJsonErrorResponseBodyProvider implements JsonErrorResponseBo
             Error error = errorContext.getErrors().get(0);
             error.getTitle().ifPresent(problemBuilder::withTitle);
             if (includeErrorMessage(errorContext)) {
-                problemBuilder.withDetail(error.getMessage());
+                problemBuilder.withDetail(errorMessage(errorContext, error, httpStatus));
             }
             error.getPath().ifPresent(path -> problemBuilder.with("path", path));
         }
         return problemBuilder.build();
+    }
+
+    /**
+     * Since Micronaut Core 5.1.14 and 5.2.0, the error of an unhandled exception is only {@code Internal Server Error},
+     * without the exception message, unless {@code micronaut.server.error-response-include-message} allows it.
+     * When the message should be included, it is restored from the root cause, so the detail is the same on every core version.
+     *
+     * @param errorContext Error Context
+     * @param error The first error
+     * @param httpStatus HTTP Status
+     * @return The error message
+     */
+    private static String errorMessage(ErrorContext errorContext, Error error, HttpStatus httpStatus) {
+        String message = error.getMessage();
+        if (httpStatus == HttpStatus.INTERNAL_SERVER_ERROR && httpStatus.getReason().equals(message)) {
+            String exceptionMessage = errorContext.getRootCause().map(Throwable::getMessage).orElse(null);
+            if (exceptionMessage != null) {
+                return message + ": " + exceptionMessage;
+            }
+        }
+        return message;
     }
 
     /**

--- a/problem-json/src/test/groovy/io/micronaut/problem/DataLeakageIncludeMessageSpec.groovy
+++ b/problem-json/src/test/groovy/io/micronaut/problem/DataLeakageIncludeMessageSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.problem
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+
+class DataLeakageIncludeMessageSpec extends EmbeddedServerSpecification {
+
+    @Override
+    String getSpecName() {
+        'DataLeakageSpec'
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        ['spec.name': specName, 'micronaut.server.error-response-include-message': 'always']
+    }
+
+    void "the detail is omitted even when the server includes the exception message in the error message"() {
+        when:
+        client.exchange(HttpRequest.GET('/foo'), Argument.of(String), Argument.of(Map))
+
+        then:
+        HttpClientResponseException thrown = thrown()
+        Optional<Map> bodyOptional = thrown.response.getBody(Argument.of(Map))
+        bodyOptional.isPresent()
+        bodyOptional.get().keySet() == ['type', 'status'] as Set
+        bodyOptional.get()['status'] == 500
+    }
+}

--- a/problem-json/src/test/groovy/io/micronaut/problem/DataLeakageOverrideIncludeMessageSpec.groovy
+++ b/problem-json/src/test/groovy/io/micronaut/problem/DataLeakageOverrideIncludeMessageSpec.groovy
@@ -1,0 +1,30 @@
+package io.micronaut.problem
+
+import io.micronaut.core.type.Argument
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.client.exceptions.HttpClientResponseException
+
+class DataLeakageOverrideIncludeMessageSpec extends EmbeddedServerSpecification {
+
+    @Override
+    String getSpecName() {
+        'DataLeakageOverrideSpec'
+    }
+
+    @Override
+    Map<String, Object> getConfiguration() {
+        ['spec.name': specName, 'micronaut.server.error-response-include-message': 'always']
+    }
+
+    void "the exception message is not repeated when the server already includes it in the error message"() {
+        when:
+        client.exchange(HttpRequest.GET('/foo'), Argument.of(String), Argument.of(Map))
+
+        then:
+        HttpClientResponseException thrown = thrown()
+        Optional<Map> bodyOptional = thrown.response.getBody(Argument.of(Map))
+        bodyOptional.isPresent()
+        bodyOptional.get()['status'] == 500
+        bodyOptional.get()['detail'] == "Internal Server Error: foo data"
+    }
+}

--- a/problem-json/src/test/groovy/io/micronaut/problem/DefaultProblemDetailSpec.groovy
+++ b/problem-json/src/test/groovy/io/micronaut/problem/DefaultProblemDetailSpec.groovy
@@ -1,0 +1,37 @@
+package io.micronaut.problem
+
+import io.micronaut.http.HttpRequest
+import io.micronaut.http.HttpStatus
+import io.micronaut.http.server.exceptions.response.ErrorContext
+import io.micronaut.problem.conf.ProblemConfiguration
+import spock.lang.Specification
+
+class DefaultProblemDetailSpec extends Specification {
+
+    ProblemJsonErrorResponseBodyProvider provider = new ProblemJsonErrorResponseBodyProvider(Stub(ProblemConfiguration)) {
+        @Override
+        protected boolean includeErrorMessage(ErrorContext errorContext) {
+            true
+        }
+    }
+
+    void "the detail of error '#message' with cause #cause and status #status is '#detail'"() {
+        given:
+        ErrorContext errorContext = ErrorContext.builder(HttpRequest.GET('/foo'))
+                .cause(cause)
+                .errorMessage(message)
+                .build()
+
+        expect:
+        provider.defaultProblem(errorContext, status).detail == detail
+
+        where:
+        message                           | cause                           | status                           || detail
+        'Internal Server Error'           | new RuntimeException('foo data') | HttpStatus.INTERNAL_SERVER_ERROR || 'Internal Server Error: foo data'
+        'Internal Server Error: foo data' | new RuntimeException('foo data') | HttpStatus.INTERNAL_SERVER_ERROR || 'Internal Server Error: foo data'
+        'Internal Server Error'           | new RuntimeException()           | HttpStatus.INTERNAL_SERVER_ERROR || 'Internal Server Error'
+        'Internal Server Error'           | null                             | HttpStatus.INTERNAL_SERVER_ERROR || 'Internal Server Error'
+        'Internal Server Error'           | new RuntimeException('foo data') | HttpStatus.BAD_REQUEST           || 'Internal Server Error'
+        'Bad Request'                     | new RuntimeException('foo data') | HttpStatus.BAD_REQUEST           || 'Bad Request'
+    }
+}

--- a/src/main/docs/guide/customizingProblemErrorResponseProcessor.adoc
+++ b/src/main/docs/guide/customizingProblemErrorResponseProcessor.adoc
@@ -7,3 +7,5 @@ You can extend api:problem.ProblemJsonErrorResponseBodyProvider[] to customize t
 include::problem-json/src/test/java/io/micronaut/problem/ProblemErrorResponseProcessorReplacement.java[tag=clazz]
 ----
 
+When `includeErrorMessage` returns `true` for an unhandled exception, the `detail` contains the exception message (for example `Internal Server Error: foo data`), whatever the value of Micronaut's `micronaut.server.error-response-include-message` setting.
+


### PR DESCRIPTION
Part of micronaut-projects/micronaut-core#13110 (rolling out core 5.2).

## Problem
On core 5.2.0, `DataLeakageOverrideSpec` fails: an `includeErrorMessage` override that opts in to the problem `detail` gets `Internal Server Error` instead of `Internal Server Error: foo data`.

Core commit 05421f2708 (in 5.1.14 and 5.2.0) added `micronaut.server.error-response-include-message` (`never` | `always` | `on-param`, default `never`). For an unhandled exception, `RouteExecutor` now sets the `ErrorContext` error to plain `Internal Server Error` unless the setting allows the message. The raw message moved to the new `ErrorContext.getExceptionMessage()`. `ProblemJsonErrorResponseBodyProvider.defaultProblem` built the detail from that first error's message, so the opt-in no longer had a message to expose.

## Fix
When `includeErrorMessage` returns `true`, the status is 500, and the error message is the bare reason, the detail is rebuilt from the root cause's message as `Internal Server Error: <message>`. This gives the same detail as before on every core version.

- Why the root cause and not `getExceptionMessage()`: this branch compiles against core 5.1.3, which doesn't have that method. `RouteExecutor` fills it from `cause.getMessage()` on the same cause that `getRootCause()` returns, so the value is identical.
- When core already includes the message (5.1.13 and older, or `error-response-include-message: always`), the error is not the bare reason, so nothing is appended twice.
- The default is unchanged: without an override, no `detail` is emitted, whatever the core setting.

Tests: `DataLeakageOverrideIncludeMessageSpec` covers the opt-in with `always` (no repeated message), and `DataLeakageIncludeMessageSpec` covers the default with `always` (still no detail). `DefaultProblemDetailSpec` builds the `ErrorContext` by hand, so every branch is covered whatever core CI builds against. On core 5.1.3 the restoring branch never runs otherwise. The guide notes that the opt-in detail doesn't depend on the core setting.

## Verification
`./gradlew check --continue`:
- Current catalog (core 5.1.3): 27 tests, 0 failed (1 skipped).
- Locally with `micronaut = "5.2.0"`: 27 tests, 0 failed (1 skipped). Without the fix: 25 tests, 1 failed (`DataLeakageOverrideSpec`), with no other 5.2-only failures.

## Notes
- This PR doesn't bump core. Renovate's #561 bumps 5.1.x to core 5.2.0. 5.1.x has no `v5.1.*` release, so it is an unreleased minor where core 5.2 may land, and it can merge after this PR.
- `gradle.properties` on 5.1.x still says `projectVersion=5.0.0-SNAPSHOT`, although v5.0.0 was released from 5.0.x on 2026-06-29 (5.0.x is at 5.0.1-SNAPSHOT). 5.1.x was branched from 5.0.x just before that release and never got a version bump. It should be `5.1.0-SNAPSHOT`. That change is left out of this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

