### PR TITLE
Start 5.1.x at 5.1.0-SNAPSHOT

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
-projectVersion=5.0.0-SNAPSHOT
+projectVersion=5.1.0-SNAPSHOT
 projectGroup=io.micronaut.problem
 
 title=Micronaut Problem JSON


### PR DESCRIPTION
Sets projectVersion 5.1.0-SNAPSHOT on `5.1.x`, the new, unreleased minor branch of this project.

Core 5.2 may only land in a new, unreleased minor of each library. Tracked in micronaut-projects/micronaut-core#13110.

🤖 Generated with [Claude Code](https://claude.com/claude-code)